### PR TITLE
Updated context on fields on sale order in order to show address

### DIFF
--- a/sale_distributor/models/res_partner.py
+++ b/sale_distributor/models/res_partner.py
@@ -34,12 +34,14 @@ class ResPartner(models.Model):
         """
         result = []
         for s in self:
-            if s.type in ["delivery", "invoice"]:
-                street = str(s.street) + ", " if s.street else "" 
+            if s._context.get('bista_show_address'):
+                street = str(s.street) + ", " if s.street else ""
+                street2 = str(s.street2) + ", " if s.street2 else ""
                 city = str(s.city) + ", " if s.city else ""
                 state = str(s.state_id.code) + " " if s.state_id else ""
-                zip = str(s.zip) if s.zip else ""
-                name = street + city + state + zip
+                zipcode = str(s.zip) if s.zip else ""
+                country = ", " + str(s.country_id.name) if s.country_id else ""
+                name = street + street2 + city + state + zipcode + country
                 result.append((s.id, name))
             elif s.sequence_name:
                 name = '[' + str(s.sequence_name) + '] ' + str(s.name)

--- a/sale_distributor/view/sale_order.xml
+++ b/sale_distributor/view/sale_order.xml
@@ -72,11 +72,11 @@
             <xpath expr="//page[@name='other_information']/group/group[@name='sale_shipping']" position="replace">
             </xpath>
             <xpath expr="//field[@name='partner_invoice_id']" position="attributes">
-                <attribute name="context">{'show_address': True}</attribute>
+                <attribute name="context">{'default_type':'invoice', 'show_address': True, 'bista_show_address': True}</attribute>
                 <attribute name="domain">['|',('id', '=', partner_id), ('parent_id', '=', partner_id)]</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_shipping_id']" position="attributes">
-                <attribute name="context">{'show_address': True}</attribute>
+                <attribute name="context">{'default_type':'delivery', 'show_address': True, 'bista_show_address': True}</attribute>
                 <attribute name="domain">['|',('id', '=', partner_id), ('parent_id', '=', partner_id)]</attribute>
             </xpath>
             <xpath expr="//form/sheet/group/group/field[@name='payment_term_id']" position="after">


### PR DESCRIPTION
I have fixed it this time. Found that the context for the field was being updated in another place.

So I added the key 'bista_show_address' to the two fields,
partner_invoice_id and partner_shipping_id. Then in the name_get
method, check for this in the context dictionary and set the name
appropriately.

Looking at other places in Odoo, did not find that the customer
display had changed.