### PR TITLE
[FEA] "Ship To Here" on sale order split lines results in extra delivery

### DIFF
--- a/sale_distributor/wizard/notification.py
+++ b/sale_distributor/wizard/notification.py
@@ -30,7 +30,8 @@ class NotificationMessage(models.TransientModel):
             route_id = self.env.ref('stock_dropshipping.route_drop_shipping').id
             dict.update({'line_type': 'dropship','route_id': route_id})
         elif self._context.get('ship_from_here'):
-            dict.update({'line_type': 'stock'})
+            route_id = self.env.ref('stock.route_warehouse0_mto').id
+            dict.update({'line_type': 'stock', 'route_id': route_id})
 
         if not self.order_id:
             if self.qty <= 0.0:


### PR DESCRIPTION
Have feature where when the user creates a split line with a "Ship
to Here" button on the sale order line form, this will upon
confirmation create a new delivery ticket for each of these items.

If there is only one item with "Ship to Here" as its method, then
only one delivery ticket is created.