### PR TITLE
[IMP] On vendor tabs, the active tab is highlighted.

### DIFF
--- a/sale_distributor/__manifest__.py
+++ b/sale_distributor/__manifest__.py
@@ -24,6 +24,7 @@
         'view/sale_order.xml',
         'view/res_partner_view.xml',
         'view/vendor_stock_view.xml',
+        'view/vendor_tabs_css.xml',
         'security/ir.model.access.csv',
     ],
     'demo': [

--- a/sale_distributor/static/src/css/vendor_tab.css
+++ b/sale_distributor/static/src/css/vendor_tab.css
@@ -1,0 +1,5 @@
+/* causes a vendor tab on the sales order line to darken when made active */ 
+div > div > main > div > div > div > div.o_notebook > div.o_notebook_headers > ul > li > a.nav-link.nav-link.active {
+    background-color: #d2d2d6 !important;
+}
+

--- a/sale_distributor/view/vendor_tabs_css.xml
+++ b/sale_distributor/view/vendor_tabs_css.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <!-- Adds in CSS that causes a vendor tab on the sales order line to darken when made active -->
+        <template id="assets_backend" name="sale_distributor_assets" inherit_id="web.assets_backend">
+            <xpath expr="//link[last()]" position="after">
+                <link rel="stylesheet" type="text/css" href="/sale_distributor/static/src/css/vendor_tab.css"/>
+            </xpath>
+        </template>
+    </data>     
+</odoo>
+


### PR DESCRIPTION
This adds some css so that the active vendor tab on the sales order line form is highlighted.